### PR TITLE
パラメータにpasswordがない場合の条件分岐追加

### DIFF
--- a/project/main.go
+++ b/project/main.go
@@ -85,12 +85,22 @@ func editRestaurantFunc(ctx *gin.Context) {
 		return
 	}
 	editedId := 0
-	pool.QueryRow(
-		context.Background(),
-		"UPDATE restaurants SET email = $1, password = $2, name = $3, phone_number = $4, address = $5, description = $6, category_id = $7 " +
-		"WHERE id = $8 RETURNING id;",
-		&editRestaurant.Email, &editRestaurant.Password, &editRestaurant.Name, &editRestaurant.PhoneNumber, &editRestaurant.Address, &editRestaurant.Description, &editRestaurant.CategoryId, &editRestaurant.Id,
-	).Scan(&editedId)
+	// パスワードがない場合パスワード以外のみをアップデートする（フロント側でユーザーのパスワードを保持できないため）
+	if editRestaurant.Password == "" {
+		pool.QueryRow(
+			context.Background(),
+			"UPDATE restaurants SET email = $1, name = $2, phone_number = $3, address = $4, description = $5, category_id = $6 " +
+			"WHERE id = $7 RETURNING id;",
+			&editRestaurant.Email, &editRestaurant.Name, &editRestaurant.PhoneNumber, &editRestaurant.Address, &editRestaurant.Description, &editRestaurant.CategoryId, &editRestaurant.Id,
+		).Scan(&editedId)
+	} else {
+		pool.QueryRow(
+			context.Background(),
+			"UPDATE restaurants SET email = $1, password = $2, name = $3, phone_number = $4, address = $5, description = $6, category_id = $7 " +
+			"WHERE id = $8 RETURNING id;",
+			&editRestaurant.Email, &editRestaurant.Password, &editRestaurant.Name, &editRestaurant.PhoneNumber, &editRestaurant.Address, &editRestaurant.Description, &editRestaurant.CategoryId, &editRestaurant.Id,
+		).Scan(&editedId)
+	}
 
 	if(editedId == 0) {
 		ctx.JSON(400, gin.H{


### PR DESCRIPTION
b022c3fb48ae9b29f4db3ebde04c2d9f6a1e4d1f

ログイン時からフロント側でユーザーのパスワードを持つことができないからプロフィール更新の処理時にパスワードの値なしでAPIにリクエストを送るとパスワードの値が空文字か何かで上書きされてしまい、再ログイン時にログインできなくなる現象が起きているのでAPIの該当部分で条件分岐を加えて修正しました。

`dev`と当ブランチの動作の違いの確認お願いします。

@SEKI-YUTA 